### PR TITLE
Added route guard for login page

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -27,7 +27,16 @@ export default new Router({
     {
       path: "/login",
       name: "login",
-      component: Login
+      component: Login,
+      beforeEnter(to, from, next) {
+        firebase.auth().onAuthStateChanged(user => {
+          if (user) {
+            next("/");
+          } else {
+            next();
+          }
+        });
+      }
     },
     {
       path: "/export",


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request adds a route guard for the login page so it can't be accessed when the user is already logged in. Fixes #25.

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
Works as expected - user can't enter login page when already logged in; the user must first logout
